### PR TITLE
Fix database existence

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -93,7 +93,7 @@ class Chef
         stdout, stderr = exec_in_pg_cluster(cluster_version, cluster_name, 'SELECT datname FROM pg_database')
         fail "postgresql create_database: can't get database list" unless stderr.empty?
 
-        if stdout.include? cluster_database
+        if stdout.gsub(/\s+/,' ').split(' ').include? cluster_database
           log("postgresql create_database: database '#{cluster_database}' already exists, skiping")
           return nil
 


### PR DESCRIPTION
The old version used include? method for string, so it return true for any exact substring.
Example:
"db_prod
db2
".include?('db') returns true
This mean recipe think that db database exists, but it doesn't
I'm using it on 9.4