### PR TITLE
Fixing postgres hacks to set params only if not defined in wrapper re…

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -105,8 +105,8 @@ class Chef
       end
 
       def configuration_hacks(configuration, cluster_version)
-        configuration['unix_socket_directory'] = '/var/run/postgresql' if cluster_version.to_f < 9.3
-        configuration['unix_socket_directories'] = '/var/run/postgresql' if cluster_version.to_f >= 9.3
+        configuration['unix_socket_directory'] ||= '/var/run/postgresql' if cluster_version.to_f < 9.3
+        configuration['unix_socket_directories'] ||= '/var/run/postgresql' if cluster_version.to_f >= 9.3
         configuration.delete('wal_receiver_status_interval') if cluster_version.to_f < 9.1
         configuration.delete('hot_standby_feedback') if cluster_version.to_f < 9.1
       end

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@express42.com'
 license          'MIT'
 description      'Installs and configures postgresql for clients or servers'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '1.1.15'
+version          '1.1.16'
 
 recipe           'postgresql_lwrp::default', 'Installs postgresql client packages'
 recipe           'postgresql_lwrp::apt_official_repository', 'Setup official apt repository'


### PR DESCRIPTION
unix socket path is set directly, which doesn't allow to override it in wrapper recipe. Fixed to assign default value only if it's not set in wrapper.