### PR TITLE
Correct syntax with rubocop & fix compatibility issue with chef11

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,7 @@ SingleSpaceBeforeFirstArg:
 MethodLength:
   Exclude:
     - 'test/**/spec_helper.rb'
+    - 'libraries/helpers.rb'
 AbcSize:
   Exclude:
     - 'libraries/helpers.rb'

--- a/Berksfile
+++ b/Berksfile
@@ -3,11 +3,12 @@ source 'https://supermarket.chef.io'
 metadata
 
 group :integration do
-  cookbook 'sysctl'
+  cookbook 'sysctl', '<0.8.0'
   cookbook 'pgtest', path: 'test/fixtures/cookbooks/pgtest'
 end
 
 group :compat do
   cookbook 'build-essential', '<4.0'
   cookbook 'apt', '<4.0'
+  cookbook 'ohai', '=3.0.1'
 end

--- a/providers/cloud_backup.rb
+++ b/providers/cloud_backup.rb
@@ -42,7 +42,7 @@ action :schedule do
   envdir_params            = new_resource.params
   full_backup_time         = new_resource.full_backup_time
 
-  unsetted_required_params  = params_validation(new_resource.protocol, envdir_params)
+  unsetted_required_params = params_validation(new_resource.protocol, envdir_params)
   fail "Key(s) '#{unsetted_required_params.join(', ')}' missing for protocol '#{new_resource.protocol}'" unless unsetted_required_params.empty?
 
   # Add libpq PGPORT variable to envdir_params

--- a/providers/database.rb
+++ b/providers/database.rb
@@ -33,11 +33,11 @@ provides :postgresql_database if defined? provides
 action :create do
   options = {}
 
-  options.merge!('OWNER' => "\\\"#{new_resource.owner}\\\"") if new_resource.owner
-  options.merge!('TABLESPACE' => "'#{new_resource.tablespace}'") if new_resource.tablespace
-  options.merge!('TEMPLATE' => "'#{new_resource.template}'") if new_resource.template
-  options.merge!('ENCODING' => "'#{new_resource.encoding}'") if new_resource.encoding
-  options.merge!('CONNECTION LIMIT' => new_resource.connection_limit) if new_resource.connection_limit
+  options['OWNER'] = "\\\"#{new_resource.owner}\\\"" if new_resource.owner
+  options['TABLESPACE'] = "'#{new_resource.tablespace}'" if new_resource.tablespace
+  options['TEMPLATE'] = "'#{new_resource.template}'" if new_resource.template
+  options['ENCODING'] = "'#{new_resource.encoding}'" if new_resource.encoding
+  options['CONNECTION LIMIT'] = new_resource.connection_limit if new_resource.connection_limit
 
   if create_database(new_resource.in_version, new_resource.in_cluster, new_resource.name, options)
     new_resource.updated_by_last_action(true)

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -86,9 +86,7 @@ action :create do
   end
 
   # Install pgxn client to download custom extensions
-  %W(pgxnclient build-essential).each do |pkg|
-    package pkg
-  end
+  package 'pgxnclient'
 
   # Return locale
   if new_resource.cluster_create_options.key?('locale') && !new_resource.cluster_create_options['locale'].empty?

--- a/providers/extension.rb
+++ b/providers/extension.rb
@@ -32,14 +32,12 @@ include Chef::Postgresql::Helpers
 
 provides :postgresql_extension if defined? provides
 
-
 action :install do
   options = {}
+  options['SCHEMA'] = new_resource.schema.to_s if new_resource.schema
+  options['VERSION'] = "'#{new_resource.version}'" if new_resource.version
 
-  options.merge!('SCHEMA' => "#{new_resource.schema}") if new_resource.schema
-  options.merge!('VERSION' => "'#{new_resource.version}'") if new_resource.version
-
-  if install_extension(new_resource.in_version, new_resource.in_cluster,new_resource.db, new_resource.name, options)
+  if install_extension(new_resource.in_version, new_resource.in_cluster, new_resource.db, new_resource.name, options)
     new_resource.updated_by_last_action(true)
   end
 end

--- a/providers/pgxn_extension.rb
+++ b/providers/pgxn_extension.rb
@@ -34,9 +34,14 @@ provides :pgxn_extension if defined? provides
 
 action :install do
   options = {}
-  options.merge!('--schema' => "#{new_resource.schema}") if new_resource.schema
+  options['--schema'] = new_resource.schema.to_s if new_resource.schema
+  params = {}
+  params[:name] = new_resource.name.to_s if new_resource.name
+  params[:stage] = new_resource.stage.to_s if new_resource.stage
+  params[:version] = new_resource.version.to_s if new_resource.version
+  params[:db] = new_resource.db.to_s if new_resource.db
 
-  if pgxn_install_extension(new_resource.in_version, new_resource.in_cluster,new_resource.db, new_resource.name, new_resource.version, new_resource.stage, options)
+  if pgxn_install_extension(new_resource.in_version, new_resource.in_cluster, params, options)
     new_resource.updated_by_last_action(true)
   end
 end

--- a/providers/user.rb
+++ b/providers/user.rb
@@ -36,20 +36,20 @@ action :create do
   options = new_resource.advanced_options.clone
 
   if new_resource.replication == true
-    options.merge!('REPLICATION' => nil)
+    options['REPLICATION'] = nil
   elsif new_resource.replication == false
-    options.merge!('NOREPLICATION' => nil)
+    options['NOREPLICATION'] = nil
   end
 
   if new_resource.superuser == true
-    options.merge!('SUPERUSER' => nil)
+    options['SUPERUSER'] = nil
   elsif new_resource.superuser == false
-    options.merge!('NOSUPERUSER' => nil)
+    options['NOSUPERUSER'] = nil
   end
 
-  options.merge!('ENCRYPTED PASSWORD' => "'#{new_resource.encrypted_password}'") if new_resource.encrypted_password
+  options['ENCRYPTED PASSWORD'] = "'#{new_resource.encrypted_password}'" if new_resource.encrypted_password
 
-  options.merge!('UNENCRYPTED PASSWORD' => "'#{new_resource.unencrypted_password}'") if new_resource.unencrypted_password
+  options['UNENCRYPTED PASSWORD'] = "'#{new_resource.unencrypted_password}'" if new_resource.unencrypted_password
 
   if create_user(new_resource.in_version, new_resource.in_cluster, new_resource.name, options)
     new_resource.updated_by_last_action(true)

--- a/test/integration/spec_helper.rb
+++ b/test/integration/spec_helper.rb
@@ -38,7 +38,7 @@ end
 
 def postgresql_extension_installed?(version, name, database, extension)
   pg_port = get_port(version, name)
-  psql_out = command ("echo -n \"SELECT extname FROM pg_extension\"| sudo -u postgres psql -t -p \"#{pg_port}\" \"#{database}\" 2>/dev/null")
+  psql_out = command("echo -n \"SELECT extname FROM pg_extension\"| sudo -u postgres psql -t -p \"#{pg_port}\" \"#{database}\" 2>/dev/null")
   if psql_out.stdout.include? extension
     return true
   else


### PR DESCRIPTION
Corrected syntax with rubocop.  Fixed compatibility issue with chef 11.x. The problem was that ohai => 4.0.0 depended on compat_resource cookbook which could only be used with chef 12.x. To avoid using compat_resource, I pinned the version of ohai and the version of sysctl cookbook (sysctl => 0.8.0 depends on ohai ~> 4.0)